### PR TITLE
Fix inconsistent namings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ p0443_v2::immediate_task run_tcp_client(mqtt5::client<tcp::socket>& client)
     opts.last_will->delay_interval = std::chrono::seconds{10};
     opts.last_will->quality_of_service = 1_qos;
 
-    co_await client.connect_socket(hostname, port);
+    co_await client.socket_connector(hostname, port);
     std::cout << "Socket connected...\n";
-    co_await client.handshake(opts);
+    co_await client.handshaker(opts);
     std::cout << "Handshake complete...\n";
 
     // A normal publisher can only be used once, either by co_await

--- a/include/mqtt5/client.hpp
+++ b/include/mqtt5/client.hpp
@@ -143,14 +143,14 @@ public:
         return connection_.get_executor();
     }
 
-    auto connect_socket(boost::string_view host, boost::string_view port);
+    auto socket_connector(boost::string_view host, boost::string_view port);
 
     template <int N>
     auto &get_nth_layer() {
         return get_nth_layer_impl<N>(connection_);
     }
 
-    auto handshake(connect_options opts) {
+    auto handshaker(connect_options opts) {
         connect_opts_ = std::move(opts);
         return detail::connect_sender{this};
     }
@@ -396,7 +396,7 @@ void client<Stream>::close()
 }
 
 template <class Stream>
-auto client<Stream>::connect_socket(boost::string_view host, boost::string_view port) {
+auto client<Stream>::socket_connector(boost::string_view host, boost::string_view port) {
     return p0443_v2::transform(
         p0443_v2::then(p0443_v2::asio::resolve(executor_, host.to_string(), port.to_string()),
                        [this](auto results) {

--- a/samples/client-connect/sample-client-connect.cpp
+++ b/samples/client-connect/sample-client-connect.cpp
@@ -36,9 +36,9 @@ p0443_v2::immediate_task run_tcp_client(mqtt5::client<tcp::socket> &client) {
     opts.last_will->quality_of_service = 1_qos;
     opts.last_will->content_type = "application/json";
 
-    co_await client.connect_socket(hostname, port);
+    co_await client.socket_connector(hostname, port);
     std::cout << "Socket connected...\n";
-    co_await client.handshake(opts);
+    co_await client.handshaker(opts);
     std::cout << "Handshake complete...\n";
 
     // A normal publisher can only be used once, either by co_await
@@ -83,9 +83,9 @@ run_websocket_client(mqtt5::client<ws::stream<boost::beast::tcp_stream>> &client
         request.set(boost::beast::http::field::sec_websocket_protocol, "mqtt");
     }));
 
-    co_await client.connect_socket(hostname, port);
+    co_await client.socket_connector(hostname, port);
     co_await p0443_v2::asio::handshake(client.get_nth_layer<1>(), hostname, "/mqtt");
-    co_await client.handshake(opts);
+    co_await client.handshaker(opts);
 
     auto alias_setter = [](mqtt5::protocol::publish &pub) { pub.properties.topic_alias = 1; };
 


### PR DESCRIPTION
Functions returning senders should be named to indicate that
the returned object needs to be started for the action to initiate.

For instance `client.connect_socket` leads one to believe that
the socket connection procedure will begin immediately. In reality
it returned a sender that had to be started for the socket to connect.

This brings the client-facing interface in line since we already had
`publisher` and `reusable_publisher`, which already adhered to this
convention.

`client::connect_socket` -> `client::socket_connector`
`client::handshake` -> `client::handshaker`