### PR TITLE
Remove repetition of receiver base classes

### DIFF
--- a/include/mqtt5/client.hpp
+++ b/include/mqtt5/client.hpp
@@ -86,7 +86,7 @@ private:
     friend struct detail::connect_sender;
 
     net::executor executor_;
-    std::vector<std::unique_ptr<detail::connect_sender_receiver_base>> connect_receivers_;
+    std::vector<std::unique_ptr<detail::message_receiver_base<>>> connect_receivers_;
     connection<Stream> connection_;
     net::steady_timer connect_and_ping_timer_;
     net::steady_timer keep_alive_timer_;

--- a/include/mqtt5/detail/connect_sender.hpp
+++ b/include/mqtt5/detail/connect_sender.hpp
@@ -10,16 +10,10 @@
 #include <p0443_v2/set_error.hpp>
 #include <p0443_v2/set_value.hpp>
 
+#include "message_receiver_base.hpp"
+
 namespace mqtt5::detail
 {
-struct connect_sender_receiver_base
-{
-    virtual ~connect_sender_receiver_base() = default;
-
-    virtual void set_value() = 0;
-    virtual void set_done() = 0;
-    virtual void set_error(std::exception_ptr) = 0;
-};
 template <class Client>
 struct connect_sender
 {
@@ -48,7 +42,7 @@ struct connect_sender
     };
 
     template <class Receiver>
-    struct receiver_impl : connect_sender_receiver_base
+    struct receiver_impl : detail::message_receiver_base<>
     {
         p0443_v2::remove_cvref_t<Receiver> next_;
 

--- a/include/mqtt5/detail/message_receiver_base.hpp
+++ b/include/mqtt5/detail/message_receiver_base.hpp
@@ -1,0 +1,20 @@
+
+//          Copyright Andreas Wass 2004 - 2020.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+namespace mqtt5::detail
+{
+template<class...Values>
+struct message_receiver_base
+{
+    virtual ~message_receiver_base() = default;
+
+    virtual void set_value(Values...) = 0;
+    virtual void set_done() = 0;
+    virtual void set_error(std::exception_ptr) = 0;
+};
+}

--- a/include/mqtt5/detail/publish_sender.hpp
+++ b/include/mqtt5/detail/publish_sender.hpp
@@ -9,20 +9,14 @@
 #include "mqtt5/quality_of_service.hpp"
 #include <mqtt5/protocol/publish.hpp>
 
+#include "message_receiver_base.hpp"
+
 namespace mqtt5::detail
 {
-struct publish_receiver_base
-{
-    virtual void set_value(mqtt5::puback_reason_code code) = 0;
-    virtual void set_done() = 0;
-    virtual void set_error(std::exception_ptr e) = 0;
-
-    virtual ~publish_receiver_base() = default;
-};
 struct in_flight_publish
 {
     protocol::publish message_;
-    std::unique_ptr<publish_receiver_base> receiver_;
+    std::unique_ptr<detail::message_receiver_base<mqtt5::puback_reason_code>> receiver_;
 };
 
 template <class Client, class Modifier>
@@ -53,7 +47,7 @@ struct publish_sender
         Modifier modifying_function_;
         Client *client_;
 
-        struct publish_receiver : publish_receiver_base
+        struct publish_receiver : detail::message_receiver_base<mqtt5::puback_reason_code>
         {
             Receiver next_;
 
@@ -142,7 +136,7 @@ struct reusable_publish_sender
         Modifier modifying_function_;
         Client *client_;
 
-        struct publish_receiver : publish_receiver_base
+        struct publish_receiver : message_receiver_base<mqtt5::puback_reason_code>
         {
             Receiver next_;
 

--- a/include/mqtt5/detail/subscribe_sender.hpp
+++ b/include/mqtt5/detail/subscribe_sender.hpp
@@ -14,6 +14,8 @@
 #include <p0443_v2/type_traits.hpp>
 #include <vector>
 
+#include "message_receiver_base.hpp"
+
 namespace mqtt5
 {
 enum class subscription_retain_handling {
@@ -51,19 +53,10 @@ struct subscribe_result
 };
 namespace detail
 {
-struct subscribe_receiver_base
-{
-    virtual void set_value(subscribe_result results) = 0;
-    virtual void set_done() = 0;
-    virtual void set_error(std::exception_ptr e) = 0;
-
-    virtual ~subscribe_receiver_base() = default;
-};
-
 struct in_flight_subscribe
 {
     protocol::subscribe message_;
-    std::unique_ptr<subscribe_receiver_base> receiver_;
+    std::unique_ptr<message_receiver_base<subscribe_result>> receiver_;
 };
 
 template <class Client, class Modifier>
@@ -89,7 +82,7 @@ struct subscribe_sender
         Modifier modifier_;
         std::vector<single_subscription> subscriptions_;
 
-        struct receiver : subscribe_receiver_base
+        struct receiver : message_receiver_base<subscribe_result>
         {
             Receiver next_;
             receiver(Receiver &&next) : next_(std::move(next)) {

--- a/include/mqtt5/detail/unsubscribe_sender.hpp
+++ b/include/mqtt5/detail/unsubscribe_sender.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <mqtt5/protocol/unsubscribe.hpp>
+#include "message_receiver_base.hpp"
 
 #include <p0443_v2/type_traits.hpp>
 
@@ -14,19 +15,10 @@
 
 namespace mqtt5::detail
 {
-struct unsubscribe_receiver_base
-{
-    virtual void set_value(std::vector<std::uint8_t> codes) = 0;
-    virtual void set_done() = 0;
-    virtual void set_error(std::exception_ptr e) = 0;
-
-    virtual ~unsubscribe_receiver_base() = default;
-};
-
 struct in_flight_unsubscribe
 {
     mqtt5::protocol::unsubscribe message_;
-    std::unique_ptr<unsubscribe_receiver_base> receiver_;
+    std::unique_ptr<message_receiver_base<std::vector<std::uint8_t>>> receiver_;
 };
 
 template<class Client>
@@ -50,7 +42,7 @@ struct unsubscribe_sender
         Client* client_;
         Receiver receiver_;
 
-        struct receiver: unsubscribe_receiver_base
+        struct receiver: message_receiver_base<std::vector<std::uint8_t>>
         {
             Receiver next_;
             receiver(Receiver &&next) : next_(std::move(next)) {


### PR DESCRIPTION
Each sender created its own receiver base class which was
exactly the same as the others, except for the value channel.

Refactor to a template base class instead.